### PR TITLE
Add `ctfd_challenge.attribution` after CTFd update to v3.7.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.7.1@sha256:6ab10e197c954f6bff3dea03bf87b8b7c8ef1072bf434030d0e5f3c61ebbd7ef
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
     env:

--- a/docs/data-sources/challenges.md
+++ b/docs/data-sources/challenges.md
@@ -25,6 +25,7 @@ description: |-
 
 Read-Only:
 
+- `attribution` (String) Attribution to the creator(s) of the challenge.
 - `category` (String) Category of the challenge that CTFd groups by on the web UI.
 - `connection_info` (String) Connection Information to connect to the challenge instance, useful for pwn or web pentest.
 - `decay` (Number)

--- a/docs/resources/challenge.md
+++ b/docs/resources/challenge.md
@@ -72,6 +72,7 @@ resource "ctfd_file" "http_file" {
 
 ### Optional
 
+- `attribution` (String) Attribution to the creator(s) of the challenge.
 - `connection_info` (String) Connection Information to connect to the challenge instance, useful for pwn, web and infrastructure pentests.
 - `decay` (Number) The decay defines from each number of solves does the decay function triggers until reaching minimum. This function is defined by CTFd and could be configured through `.function`.
 - `function` (String) Decay function to define how the challenge value evolve through solves, either linear or logarithmic.

--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -18,10 +18,8 @@ resource "ctfd_challenge" "http" {
   description = <<-EOT
         Oh non ! Je n'avais pas vu que ma connexion n'était pas chiffrée ! 
         J'espère que personne ne m'espionnait...
-
-        Authors:
-        - NicolasFgrx
     EOT
+  attribution = "NicolasFgrx"
   value       = 500
   initial     = 500
   decay       = 17
@@ -72,10 +70,8 @@ resource "ctfd_challenge" "icmp" {
         Visiblement, il s'agit d'un serveur interne. Vous pouvez nous dire de quoi il s'agit ?
 
         (La capture a été réalisée en dehors de l'infrastructure du CTF)
-
-        Authors:
-        - NicolasFgrx
     EOT
+  attribution = "NicolasFgrx"
   value       = 500
   decay       = 17
   minimum     = 50

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ctfer-io/terraform-provider-ctfd
 go 1.23.2
 
 require (
-	github.com/ctfer-io/go-ctfd v0.10.1
+	github.com/ctfer-io/go-ctfd v0.10.2
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/ctfer-io/go-ctfd v0.10.1 h1:Bxr6/qo/h1c0FYFNZv/ej839Hzo5x1VMs0v+Io8ovs8=
-github.com/ctfer-io/go-ctfd v0.10.1/go.mod h1:ebgSW8LdP/qtRCpglK4djBp+g6kU5YM98XBZKowiCeY=
+github.com/ctfer-io/go-ctfd v0.10.2 h1:DpQSaxcHN7ugC72xlpEl0HIUbusOSolPkWD8Ki7vc7U=
+github.com/ctfer-io/go-ctfd v0.10.2/go.mod h1:ebgSW8LdP/qtRCpglK4djBp+g6kU5YM98XBZKowiCeY=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/provider/challenge_data_source.go
+++ b/provider/challenge_data_source.go
@@ -59,6 +59,10 @@ func (ch *challengeDataSource) Schema(ctx context.Context, req datasource.Schema
 							MarkdownDescription: "Description of the challenge, consider using multiline descriptions for better style.",
 							Computed:            true,
 						},
+						"attribution": schema.StringAttribute{
+							MarkdownDescription: "Attribution to the creator(s) of the challenge.",
+							Computed:            true,
+						},
 						"connection_info": schema.StringAttribute{
 							MarkdownDescription: "Connection Information to connect to the challenge instance, useful for pwn or web pentest.",
 							Computed:            true,

--- a/provider/challenge_resource.go
+++ b/provider/challenge_resource.go
@@ -43,6 +43,7 @@ type challengeResourceModel struct {
 	Name           types.String                  `tfsdk:"name"`
 	Category       types.String                  `tfsdk:"category"`
 	Description    types.String                  `tfsdk:"description"`
+	Attribution    types.String                  `tfsdk:"attribution"`
 	ConnectionInfo types.String                  `tfsdk:"connection_info"`
 	MaxAttempts    types.Int64                   `tfsdk:"max_attempts"`
 	Function       types.String                  `tfsdk:"function"`
@@ -83,6 +84,10 @@ func (r *challengeResource) Schema(ctx context.Context, req resource.SchemaReque
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the challenge, consider using multiline descriptions for better style.",
 				Required:            true,
+			},
+			"attribution": schema.StringAttribute{
+				MarkdownDescription: "Attribution to the creator(s) of the challenge.",
+				Optional:            true,
 			},
 			"connection_info": schema.StringAttribute{
 				MarkdownDescription: "Connection Information to connect to the challenge instance, useful for pwn, web and infrastructure pentests.",
@@ -252,6 +257,7 @@ func (r *challengeResource) Create(ctx context.Context, req resource.CreateReque
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
+		Attribution:    data.Attribution.ValueStringPointer(),
 		ConnectionInfo: data.ConnectionInfo.ValueStringPointer(),
 		MaxAttempts:    utils.ToInt(data.MaxAttempts),
 		Function:       data.Function.ValueStringPointer(),
@@ -383,6 +389,7 @@ func (r *challengeResource) Update(ctx context.Context, req resource.UpdateReque
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
+		Attribution:    data.Attribution.ValueStringPointer(),
 		ConnectionInfo: data.ConnectionInfo.ValueStringPointer(),
 		MaxAttempts:    utils.ToInt(data.MaxAttempts),
 		Function:       data.Function.ValueStringPointer(),
@@ -520,6 +527,7 @@ func (chall *challengeResourceModel) Read(ctx context.Context, client *api.Clien
 	chall.Name = types.StringValue(res.Name)
 	chall.Category = types.StringValue(res.Category)
 	chall.Description = types.StringValue(res.Description)
+	chall.Attribution = types.StringPointerValue(res.Attribution)
 	chall.ConnectionInfo = utils.ToTFString(res.ConnectionInfo)
 	chall.MaxAttempts = utils.ToTFInt64(res.MaxAttempts)
 	chall.Function = utils.ToTFString(res.Function)

--- a/provider/challenge_resource_test.go
+++ b/provider/challenge_resource_test.go
@@ -19,14 +19,12 @@ resource "ctfd_challenge" "http" {
 	description = <<-EOT
         Oh no ! I did not see my connection was no encrypted !
         I hope no one spied me...
-
-        Authors:
-        - Nicolas
     EOT
-	value    = 500
-    decay    = 20
-    minimum  = 50
-    state    = "hidden"
+	attribution = "Nicolas"
+	value       = 500
+    decay       = 20
+    minimum     = 50
+    state       = "hidden"
 
 	topics = [
 		"Network"
@@ -56,14 +54,12 @@ resource "ctfd_challenge" "http" {
 	description = <<-EOT
         Oh no ! I did not see my connection was no encrypted !
         I hope no one spied me...
-
-        Authors:
-        - NicolasFgrx
     EOT
-	value    = 500
-    decay    = 17
-    minimum  = 50
-    state    = "visible"
+	attribution = "NicolasFgrx"
+	value       = 500
+    decay       = 17
+    minimum     = 50
+    state       = "visible"
 
 	topics = [
 		"Network"
@@ -82,12 +78,10 @@ resource "ctfd_challenge" "icmp" {
 		At first glance, it seems to be an internal one. Can you tell what it is ?
 
 		(The network capture was realized out of the CTF infrastructure)
-
-		Authors:
-		- NicolasFgrx
 	EOT
-	value   = 500
-	type    = "standard"
+	attribution = "NicolasFgrx"
+	value       = 500
+	type        = "standard"
 
 	requirements = {
 		behavior      = "anonymized"


### PR DESCRIPTION
This PR updates CTFd to v3.7.5, thus fixes the `ctfd_challenge.attribution` problem.