### PR TITLE
On file encoding: a solution with base64 only

### DIFF
--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -49,7 +49,6 @@ resource "ctfd_file" "http_file" {
 ### Optional
 
 - `challenge_id` (String) Challenge of the file.
-- `content` (String, Sensitive) Raw content of the file, perfectly fit the use-cases of a .txt document or anything with a simple binary content. You could provide it from the file-system using `file("${path.module}/...")`.
 - `contentb64` (String, Sensitive) Base 64 content of the file, perfectly fit the use-cases of complex binaries. You could provide it from the file-system using `filebase64("${path.module}/...")`.
 - `location` (String) Location where the file is stored on the CTFd instance, for download purposes.
 

--- a/provider/file_resource_test.go
+++ b/provider/file_resource_test.go
@@ -23,18 +23,22 @@ resource "ctfd_challenge_standard" "example" {
 resource "ctfd_file" "pouet" {
 	challenge_id = ctfd_challenge_standard.example.id
 	name         = "pouet.txt"
-	content      = "Pouet is a clown cat"
+	contentb64   = "UG91ZXQgaXMgYSBjbG93biBjYXQK"
 }
 
 resource "ctfd_file" "pouet_2" {
-	name         = "pouet-2.txt"
-	content      = "Pouet is a clown cat, but has not challenge"
+	name       = "pouet-2.txt"
+	contentb64 = "UG91ZXQgaXMgYSBjbG93biBjYXQsIGJ1dCBoYXMgbm90IGNoYWxsZW5nZQo="
 }
 `,
 			},
 			// ImportState testing
 			{
 				ResourceName:      "ctfd_file.pouet",
+				ImportState:       true,
+				ImportStateVerify: true,
+			}, {
+				ResourceName:      "ctfd_file.pouet_2",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -51,12 +55,12 @@ resource "ctfd_challenge_standard" "example" {
 resource "ctfd_file" "pouet" {
 	challenge_id = ctfd_challenge_standard.example.id
 	name         = "pouet.txt"
-	content      = "Pouet the 2nd is the clowniest cat ever"
+	contentb64   = "UG91ZXQgdGhlIDJuZCBpcyB0aGUgY2xvd25pZXN0IGNhdCBldmVyCg=="
 }
 
 resource "ctfd_file" "pouet_2" {
-	name         = "pouet-2.txt"
-	content      = "Pouet is a clown cat, but has not challenge"
+	name       = "pouet-2.txt"
+	contentb64 = "UG91ZXQgaXMgYSBjbG93biBjYXQsIGJ1dCBoYXMgbm90IGNoYWxsZW5nZQo="
 }
 `,
 			},


### PR DESCRIPTION
In this PR I introduce a fix to the _file instability_ : "do I have to whether use the `content`, or the `contentb64` ?" was a common question for the provider. It led to internally providing both of them from one another... Then dealing with only the `content`.
This came at the cost of instabilities on files lifecycles, with multiple useless re-creation of the resources. Considering that pushing a file can cost a lost of resources and time, this would not be acceptable for production workloads.

My solution is to deal only with a base 64 encoding of the file, that on the very last moment I decode to raw content and send it to CTFd. I don't have other strategy available as CTFd only support multipart-encoded requests for file management.

The drawback of this PR is that it introduces a **BREAKING CHANGE** for the `ctfd_file` resource, as the `content` field is not deprecated but completely dropped.

It would further align with the common downstream usages: most of the time, challenges pushes `.zip`, `.png` or other formats that are non-UTF-8 compliant. They were all forced to use base64 encoding, which the provider dealt with easily !
Pulumi also had to use the base 64 encoding to communicate in UTF-8 over gRPC with the provider, so it was a motivation too for that change on the current TF provider. 