### PR TITLE
Bump CTFd to 3.8.4 (add position and prerequisite behavior preview for challenges)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.8.2@sha256:870e396fddf8dd1273252bae5842bda96e45d5ebbe83d1d737ef76c513055619
+        image: ctfd/ctfd:3.8.4@sha256:da25249c41d19556573f11cf3c9fd887d47830310ae8d725ad443644a35b3455
         ports:
           - 8000:8000
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-acc
 test-acc:
 	TF_ACC=1 \
-	go test ./provider/ -v -run=^TestAcc_ -count=1 -coverprofile=cov.out -coverpkg "github.com/ctfer-io/terraform-provider-ctfd/v2/provider,github.com/ctfer-io/terraform-provider-ctfd/v2/provider/utils,github.com/ctfer-io/terraform-provider-ctfd/v2/provider/validators"
+	go test ./provider/ -v -run=^TestAcc_ -count=1 -coverprofile=cov.out -coverpkg "github.com/ctfer-io/terraform-provider-ctfd/v2/..."
 
 .PHONY: docs
 docs:

--- a/docs/resources/challenge_dynamic.md
+++ b/docs/resources/challenge_dynamic.md
@@ -80,6 +80,7 @@ resource "ctfd_file" "http_file" {
 - `logic` (String) The flag validation logic.
 - `max_attempts` (Number) Maximum amount of attempts before being unable to flag the challenge.
 - `next` (Number) Suggestion for the end-user as next challenge to work on.
+- `position` (Number) The challenge position as displayed to players.
 - `requirements` (Attributes) List of required challenges that needs to get flagged before this one being accessible. Useful for skill-trees-like strategy CTF. (see [below for nested schema](#nestedatt--requirements))
 - `state` (String) State of the challenge, either hidden or visible.
 - `tags` (Set of String) List of challenge tags that will be displayed to the end-user. You could use them to give some quick insights of what a challenge involves.

--- a/docs/resources/challenge_standard.md
+++ b/docs/resources/challenge_standard.md
@@ -73,6 +73,7 @@ resource "ctfd_file" "http_file" {
 - `logic` (String) The flag validation logic.
 - `max_attempts` (Number) Maximum amount of attempts before being unable to flag the challenge.
 - `next` (Number) Suggestion for the end-user as next challenge to work on.
+- `position` (Number) The challenge position as displayed to players.
 - `requirements` (Attributes) List of required challenges that needs to get flagged before this one being accessible. Useful for skill-trees-like strategy CTF. (see [below for nested schema](#nestedatt--requirements))
 - `state` (String) State of the challenge, either hidden or visible.
 - `tags` (Set of String) List of challenge tags that will be displayed to the end-user. You could use them to give some quick insights of what a challenge involves.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ctfer-io/terraform-provider-ctfd/v2
 go 1.25.8
 
 require (
-	github.com/ctfer-io/go-ctfd v0.16.0
+	github.com/ctfer-io/go-ctfd v0.17.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.18.0
 	github.com/hashicorp/terraform-plugin-go v0.30.0
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/multierr v1.11.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/ctfer-io/go-ctfd v0.16.0 h1:BvcQwjG3hRcqmIBqzZ2OapG3w4cKBBh2TrAYIuWjK00=
-github.com/ctfer-io/go-ctfd v0.16.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
+github.com/ctfer-io/go-ctfd v0.17.0 h1:qu/FHjlOSdhRMtHB66OFzHwOnwLwHrr9w4n8EHo8Yhs=
+github.com/ctfer-io/go-ctfd v0.17.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -293,6 +293,8 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/provider/challenge_common.go
+++ b/provider/challenge_common.go
@@ -1,13 +1,13 @@
 package provider
 
 import (
-	"github.com/ctfer-io/terraform-provider-ctfd/v2/provider/utils"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
 	BehaviorHidden     = types.StringValue("hidden")
 	BehaviorAnonymized = types.StringValue("anonymized")
+	BehaviorPreview    = types.StringValue("preview")
 
 	FunctionLinear      = types.StringValue("linear")
 	FunctionLogarithmic = types.StringValue("logarithmic")
@@ -16,24 +16,4 @@ var (
 type RequirementsSubresourceModel struct {
 	Behavior      types.String   `tfsdk:"behavior"`
 	Prerequisites []types.String `tfsdk:"prerequisites"`
-}
-
-func GetAnon(str types.String) *bool {
-	switch {
-	case str.Equal(BehaviorHidden):
-		return nil
-	case str.Equal(BehaviorAnonymized):
-		return utils.Ptr(true)
-	}
-	panic("invalid anonymization value: " + str.ValueString())
-}
-
-func FromAnon(b *bool) types.String {
-	if b == nil {
-		return BehaviorHidden
-	}
-	if *b {
-		return BehaviorAnonymized
-	}
-	panic("invalid anonymization value, got boolean false")
 }

--- a/provider/challenge_common.go
+++ b/provider/challenge_common.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"github.com/ctfer-io/terraform-provider-ctfd/v2/provider/utils"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -16,4 +17,29 @@ var (
 type RequirementsSubresourceModel struct {
 	Behavior      types.String   `tfsdk:"behavior"`
 	Prerequisites []types.String `tfsdk:"prerequisites"`
+}
+
+func GetBehavior(anon *string) types.String {
+	if anon == nil {
+		return BehaviorHidden // nil is hidden (default value)
+	}
+	switch *anon {
+	case "true":
+		return BehaviorAnonymized
+	case "preview":
+		return BehaviorPreview
+	default: // "false" or anything new
+		return BehaviorHidden
+	}
+}
+
+func FromBehavior(bhv types.String) *string {
+	switch bhv {
+	case BehaviorAnonymized:
+		return utils.Ptr("true")
+	case BehaviorPreview:
+		return utils.Ptr("preview")
+	default:
+		return utils.Ptr("false") // default value is hidden
+	}
 }

--- a/provider/challenge_dynamic_resource.go
+++ b/provider/challenge_dynamic_resource.go
@@ -93,7 +93,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
+			Anonymize:     FromBehavior(data.Requirements.Behavior),
 			Prerequisites: preqs,
 		}
 	}
@@ -214,7 +214,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
+			Anonymize:     FromBehavior(data.Requirements.Behavior),
 			Prerequisites: preqs,
 		}
 	}
@@ -395,7 +395,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 			challPreqs = append(challPreqs, types.StringValue(strconv.Itoa(req)))
 		}
 		reqs = &RequirementsSubresourceModel{
-			Behavior:      types.StringPointerValue(resReqs.Anonymize),
+			Behavior:      GetBehavior(resReqs.Anonymize),
 			Prerequisites: challPreqs,
 		}
 	}

--- a/provider/challenge_dynamic_resource.go
+++ b/provider/challenge_dynamic_resource.go
@@ -93,7 +93,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     GetAnon(data.Requirements.Behavior),
+			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
 			Prerequisites: preqs,
 		}
 	}
@@ -213,7 +213,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     GetAnon(data.Requirements.Behavior),
+			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
 			Prerequisites: preqs,
 		}
 	}
@@ -392,7 +392,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 			challPreqs = append(challPreqs, types.StringValue(strconv.Itoa(req)))
 		}
 		reqs = &RequirementsSubresourceModel{
-			Behavior:      FromAnon(resReqs.Anonymize),
+			Behavior:      types.StringPointerValue(resReqs.Anonymize),
 			Prerequisites: challPreqs,
 		}
 	}

--- a/provider/challenge_dynamic_resource.go
+++ b/provider/challenge_dynamic_resource.go
@@ -110,6 +110,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 		Minimum:        utils.ToInt(data.Minimum),
 		Logic:          data.Logic.ValueString(),
 		State:          data.State.ValueString(),
+		Position:       utils.ToInt(data.Position),
 		Type:           "dynamic",
 		NextID:         utils.ToInt(data.Next),
 		Requirements:   reqs,
@@ -230,6 +231,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 		Minimum:        utils.ToInt(data.Minimum),
 		Logic:          data.Logic.ValueStringPointer(),
 		State:          data.State.ValueString(),
+		Position:       utils.ToInt(data.Position),
 		NextID:         utils.ToInt(data.Next),
 		Requirements:   reqs,
 	}, WithTracerProvider(r.fm.Tp))
@@ -371,6 +373,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 	chall.Minimum = utils.ToTFInt64(res.Minimum)
 	chall.Logic = types.StringValue(res.Logic)
 	chall.State = types.StringValue(res.State)
+	chall.Position = utils.ToTFInt64(res.Position)
 	chall.Next = utils.ToTFInt64(res.NextID)
 
 	id := utils.Atoi(chall.ID.ValueString())

--- a/provider/challenge_standard_resource.go
+++ b/provider/challenge_standard_resource.go
@@ -107,7 +107,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
+			Anonymize:     FromBehavior(data.Requirements.Behavior),
 			Prerequisites: preqs,
 		}
 	}
@@ -225,7 +225,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
+			Anonymize:     FromBehavior(data.Requirements.Behavior),
 			Prerequisites: preqs,
 		}
 	}
@@ -400,7 +400,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 			challPreqs = append(challPreqs, types.StringValue(strconv.Itoa(req)))
 		}
 		reqs = &RequirementsSubresourceModel{
-			Behavior:      types.StringPointerValue(resReqs.Anonymize),
+			Behavior:      GetBehavior(resReqs.Anonymize),
 			Prerequisites: challPreqs,
 		}
 	}

--- a/provider/challenge_standard_resource.go
+++ b/provider/challenge_standard_resource.go
@@ -52,6 +52,7 @@ type ChallengeStandardResourceModel struct {
 	Value          types.Int64                   `tfsdk:"value"`
 	Logic          types.String                  `tfsdk:"logic"`
 	State          types.String                  `tfsdk:"state"`
+	Position       types.Int64                   `tfsdk:"position"`
 	Next           types.Int64                   `tfsdk:"next"`
 	Requirements   *RequirementsSubresourceModel `tfsdk:"requirements"`
 	Tags           []types.String                `tfsdk:"tags"`
@@ -120,6 +121,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 		Value:          int(data.Value.ValueInt64()),
 		Logic:          data.Logic.ValueString(),
 		State:          data.State.ValueString(),
+		Position:       utils.ToInt(data.Position),
 		Type:           "standard",
 		NextID:         utils.ToInt(data.Next),
 		Requirements:   reqs,
@@ -237,6 +239,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 		Value:          utils.ToInt(data.Value),
 		Logic:          data.Logic.ValueStringPointer(),
 		State:          data.State.ValueString(),
+		Position:       utils.ToInt(data.Position),
 		NextID:         utils.ToInt(data.Next),
 		Requirements:   reqs,
 	}, WithTracerProvider(r.fm.Tp))
@@ -375,6 +378,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 	chall.Value = types.Int64Value(int64(res.Value))
 	chall.Logic = types.StringValue(res.Logic)
 	chall.State = types.StringValue(res.State)
+	chall.Position = utils.ToTFInt64(res.Position)
 	chall.Next = utils.ToTFInt64(res.NextID)
 
 	id := utils.Atoi(chall.ID.ValueString())
@@ -499,6 +503,10 @@ var (
 					types.StringValue("visible"),
 				}),
 			},
+		},
+		"position": schema.Int64Attribute{
+			MarkdownDescription: "The challenge position as displayed to players.",
+			Optional:            true,
 		},
 		"next": schema.Int64Attribute{
 			MarkdownDescription: "Suggestion for the end-user as next challenge to work on.",

--- a/provider/challenge_standard_resource.go
+++ b/provider/challenge_standard_resource.go
@@ -507,6 +507,8 @@ var (
 		"position": schema.Int64Attribute{
 			MarkdownDescription: "The challenge position as displayed to players.",
 			Optional:            true,
+			Computed:            true,
+			Default:             int64default.StaticInt64(0),
 		},
 		"next": schema.Int64Attribute{
 			MarkdownDescription: "Suggestion for the end-user as next challenge to work on.",

--- a/provider/challenge_standard_resource.go
+++ b/provider/challenge_standard_resource.go
@@ -106,7 +106,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     GetAnon(data.Requirements.Behavior),
+			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
 			Prerequisites: preqs,
 		}
 	}
@@ -223,7 +223,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 			preqs = append(preqs, id)
 		}
 		reqs = &api.Requirements{
-			Anonymize:     GetAnon(data.Requirements.Behavior),
+			Anonymize:     data.Requirements.Behavior.ValueStringPointer(),
 			Prerequisites: preqs,
 		}
 	}
@@ -396,7 +396,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 			challPreqs = append(challPreqs, types.StringValue(strconv.Itoa(req)))
 		}
 		reqs = &RequirementsSubresourceModel{
-			Behavior:      FromAnon(resReqs.Anonymize),
+			Behavior:      types.StringPointerValue(resReqs.Anonymize),
 			Prerequisites: challPreqs,
 		}
 	}
@@ -517,6 +517,7 @@ var (
 						validators.NewStringEnumValidator([]basetypes.StringValue{
 							BehaviorHidden,
 							BehaviorAnonymized,
+							BehaviorPreview,
 						}),
 					},
 				},

--- a/provider/challenge_standard_resource_test.go
+++ b/provider/challenge_standard_resource_test.go
@@ -62,6 +62,7 @@ resource "ctfd_challenge_standard" "http" {
 	attribution = "NicolasFgrx"
 	value       = 500
     state       = "visible"
+	position    = 1
 
 	topics = [
 		"Network"
@@ -83,6 +84,7 @@ resource "ctfd_challenge_standard" "icmp" {
 	EOT
 	attribution = "NicolasFgrx"
 	value       = 500
+	position    = 2
 
 	requirements = {
 		behavior      = "anonymized"

--- a/provider/tracing.go
+++ b/provider/tracing.go
@@ -15,6 +15,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 )
 
 const (
@@ -26,7 +27,27 @@ type OTelSetup struct {
 	TracerProvider trace.TracerProvider
 }
 
-func SetupOTelSDK(ctx context.Context, version string) (*OTelSetup, error) {
+func SetupOTelSDK(ctx context.Context, version string) (out OTelSetup, err error) {
+	var shutdownFuncs []func(context.Context) error
+
+	// shutdown calls cleanup functions registered via shutdownFuncs.
+	// The errors from the calls are joined.
+	// Each registered cleanup will be invoked once.
+
+	out.Shutdown = func(ctx context.Context) error {
+		var err error
+		for _, fn := range shutdownFuncs {
+			err = multierr.Append(err, fn(ctx))
+		}
+		shutdownFuncs = nil
+		return err
+	}
+
+	// handleErr calls shutdown for cleanup and makes sure that all errors are returned
+	handleErr := func(inErr error) {
+		err = multierr.Append(inErr, out.Shutdown(ctx))
+	}
+
 	// Set up propagator
 	prop := propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
@@ -44,25 +65,25 @@ func SetupOTelSDK(ctx context.Context, version string) (*OTelSetup, error) {
 		),
 	)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	// Then create the span exporter
-	exp, err := autoexport.NewSpanExporter(ctx)
+	exp, nerr := autoexport.NewSpanExporter(ctx)
 	if err != nil {
-		return nil, err
+		handleErr(nerr)
+		return
 	}
-	tracerProvider := sdktrace.NewTracerProvider(
+	shutdownFuncs = append(shutdownFuncs, exp.Shutdown)
+
+	out.TracerProvider = sdktrace.NewTracerProvider(
 		// We need to have the burden of a simple span processor as the process might be short-lived
 		// because a batch processor can not give enough time to export data...
 		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exp)),
 		sdktrace.WithResource(r),
 	)
 
-	return &OTelSetup{
-		Shutdown:       tracerProvider.Shutdown,
-		TracerProvider: tracerProvider,
-	}, nil
+	return
 }
 
 func StartTFSpan(

--- a/provider/utils/utils.go
+++ b/provider/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"maps"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -62,11 +63,7 @@ func Atoi(s string) int {
 // In case the same key is defined in both, b takes privilege.
 func BlindMerge[T comparable, U any](a, b map[T]U) map[T]U {
 	c := map[T]U{}
-	for k, v := range a {
-		c[k] = v
-	}
-	for k, v := range b {
-		c[k] = v
-	}
+	maps.Copy(c, a)
+	maps.Copy(c, b)
 	return c
 }


### PR DESCRIPTION
This PR:
- bump CTFd to 3.8.4;
- adds support of `position` in both `ctfd_challenge_standard` and `ctfd_challenge_dynamic` types;
- add `preview` value for challenge prerequisite behavior;
- improve OTel shutdown error handling in case of setup failure.