### PR TITLE
chore(deps): bump go-ctfd to 0.18.0, use pagination for datasources when applicable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ctfer-io/terraform-provider-ctfd/v2
 go 1.25.8
 
 require (
-	github.com/ctfer-io/go-ctfd v0.17.0
+	github.com/ctfer-io/go-ctfd v0.18.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.18.0
 	github.com/hashicorp/terraform-plugin-go v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/ctfer-io/go-ctfd v0.17.0 h1:qu/FHjlOSdhRMtHB66OFzHwOnwLwHrr9w4n8EHo8Yhs=
-github.com/ctfer-io/go-ctfd v0.17.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
+github.com/ctfer-io/go-ctfd v0.18.0 h1:rcP1rrIR4DefLOVYd7zM5NNtfB2pHivFfj6odUIZOv0=
+github.com/ctfer-io/go-ctfd v0.18.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/provider/bracket_data_source.go
+++ b/provider/bracket_data_source.go
@@ -89,7 +89,7 @@ func (data *bracketDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	var state bracketsDataSourceModel
 
-	brackets, err := data.fm.Client.GetBrackets(ctx, &api.GetBracketsParams{}, WithTracerProvider(data.fm.Tp))
+	brackets, _, err := data.fm.Client.GetBrackets(ctx, &api.GetBracketsParams{}, WithTracerProvider(data.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read CTFd Brackets",

--- a/provider/bracket_resource.go
+++ b/provider/bracket_resource.go
@@ -108,7 +108,7 @@ func (r *bracketResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Create bracket
-	res, err := r.fm.Client.PostBrackets(ctx, &api.PostBracketsParams{
+	res, _, err := r.fm.Client.PostBrackets(ctx, &api.PostBracketsParams{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
 		Type:        data.Type.ValueString(),
@@ -143,7 +143,7 @@ func (r *bracketResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	// XXX cannot get bracket by ID, so we need to query them all
-	brackets, err := r.fm.Client.GetBrackets(ctx, &api.GetBracketsParams{}, WithTracerProvider(r.fm.Tp))
+	brackets, _, err := r.fm.Client.GetBrackets(ctx, &api.GetBracketsParams{}, WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -188,7 +188,7 @@ func (r *bracketResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Update bracket
-	if _, err := r.fm.Client.PatchBrackets(ctx, data.ID.ValueString(), &api.PatchBracketsParams{
+	if _, _, err := r.fm.Client.PatchBrackets(ctx, data.ID.ValueString(), &api.PatchBracketsParams{
 		Name:        data.Name.ValueStringPointer(),
 		Description: data.Description.ValueStringPointer(),
 		Type:        data.Type.ValueStringPointer(),
@@ -216,7 +216,7 @@ func (r *bracketResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	if err := r.fm.Client.DeleteBrackets(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteBrackets(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete bracket %s, got error: %s", data.ID.ValueString(), err))
 		return
 	}

--- a/provider/challenge_dynamic_data_source.go
+++ b/provider/challenge_dynamic_data_source.go
@@ -151,7 +151,7 @@ func (data *challengeDynamicDataSource) Read(ctx context.Context, req datasource
 
 	var state challengesDynamicDataSourceModel
 
-	challs, err := data.fm.Client.GetChallenges(ctx, &api.GetChallengesParams{
+	challs, _, err := data.fm.Client.GetChallenges(ctx, &api.GetChallengesParams{
 		Type: utils.Ptr("dynamic"),
 	}, WithTracerProvider(data.fm.Tp))
 	if err != nil {

--- a/provider/challenge_dynamic_resource.go
+++ b/provider/challenge_dynamic_resource.go
@@ -97,7 +97,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 			Prerequisites: preqs,
 		}
 	}
-	res, err := r.fm.Client.PostChallenges(ctx, &api.PostChallengesParams{
+	res, _, err := r.fm.Client.PostChallenges(ctx, &api.PostChallengesParams{
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
@@ -131,7 +131,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 	// Create tags
 	challTags := make([]types.String, 0, len(data.Tags))
 	for _, tag := range data.Tags {
-		_, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
+		_, _, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Value:     tag.ValueString(),
 		}, WithTracerProvider(r.fm.Tp))
@@ -151,7 +151,7 @@ func (r *challengeDynamicResource) Create(ctx context.Context, req resource.Crea
 	// Create topics
 	challTopics := make([]types.String, 0, len(data.Topics))
 	for _, topic := range data.Topics {
-		_, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
+		_, _, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Type:      "challenge",
 			Value:     topic.ValueString(),
@@ -218,7 +218,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 			Prerequisites: preqs,
 		}
 	}
-	_, err := r.fm.Client.PatchChallenge(ctx, data.ID.ValueString(), &api.PatchChallengeParams{
+	_, _, err := r.fm.Client.PatchChallenge(ctx, data.ID.ValueString(), &api.PatchChallengeParams{
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
@@ -244,7 +244,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// Update its tags (drop them all, create new ones)
-	challTags, err := r.fm.Client.GetChallengeTags(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	challTags, _, err := r.fm.Client.GetChallengeTags(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -253,7 +253,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 	for _, tag := range challTags {
-		if err := r.fm.Client.DeleteTag(ctx, strconv.Itoa(tag.ID), WithTracerProvider(r.fm.Tp)); err != nil {
+		if _, err := r.fm.Client.DeleteTag(ctx, strconv.Itoa(tag.ID), WithTracerProvider(r.fm.Tp)); err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",
 				fmt.Sprintf("Unable to delete tag %d of challenge %s, got error: %s", tag.ID, data.ID.ValueString(), err),
@@ -263,7 +263,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 	}
 	tags := make([]types.String, 0, len(data.Tags))
 	for _, tag := range data.Tags {
-		_, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
+		_, _, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Value:     tag.ValueString(),
 		}, WithTracerProvider(r.fm.Tp))
@@ -281,7 +281,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// Update its topics (drop them all, create new ones)
-	challTopics, err := r.fm.Client.GetChallengeTopics(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	challTopics, _, err := r.fm.Client.GetChallengeTopics(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -290,7 +290,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 	for _, topic := range challTopics {
-		if err := r.fm.Client.DeleteTopic(ctx, &api.DeleteTopicArgs{
+		if _, err := r.fm.Client.DeleteTopic(ctx, &api.DeleteTopicArgs{
 			ID:   strconv.Itoa(topic.ID),
 			Type: "challenge",
 		}, WithTracerProvider(r.fm.Tp)); err != nil {
@@ -303,7 +303,7 @@ func (r *challengeDynamicResource) Update(ctx context.Context, req resource.Upda
 	}
 	topics := make([]types.String, 0, len(data.Topics))
 	for _, topic := range data.Topics {
-		_, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
+		_, _, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Type:      "challenge",
 			Value:     topic.ValueString(),
@@ -337,7 +337,7 @@ func (r *challengeDynamicResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	if err := r.fm.Client.DeleteChallenge(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteChallenge(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete challenge, got error: %s", err))
 		return
 	}
@@ -356,7 +356,7 @@ func (r *challengeDynamicResource) ImportState(ctx context.Context, req resource
 //
 
 func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Client, diags diag.Diagnostics, opts ...Option) {
-	res, err := client.GetChallenge(ctx, chall.ID.ValueString(), opts...)
+	res, _, err := client.GetChallenge(ctx, chall.ID.ValueString(), opts...)
 	if err != nil {
 		diags.AddError("Client Error", fmt.Sprintf("Unable to read challenge %s, got error: %s", chall.ID.ValueString(), err))
 		return
@@ -380,7 +380,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 
 	// Get subresources
 	// => Requirements
-	resReqs, err := client.GetChallengeRequirements(ctx, strconv.Itoa(id), opts...)
+	resReqs, _, err := client.GetChallengeRequirements(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",
@@ -402,7 +402,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 	chall.Requirements = reqs
 
 	// => Tags
-	resTags, err := client.GetChallengeTags(ctx, strconv.Itoa(id), opts...)
+	resTags, _, err := client.GetChallengeTags(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",
@@ -416,7 +416,7 @@ func (chall *ChallengeDynamicResourceModel) Read(ctx context.Context, client *Cl
 	}
 
 	// => Topics
-	resTopics, err := client.GetChallengeTopics(ctx, strconv.Itoa(id), opts...)
+	resTopics, _, err := client.GetChallengeTopics(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",

--- a/provider/challenge_standard_data_source.go
+++ b/provider/challenge_standard_data_source.go
@@ -138,7 +138,7 @@ func (data *challengeStandardDataSource) Read(ctx context.Context, req datasourc
 
 	var state challengesStandardDataSourceModel
 
-	challs, err := data.fm.Client.GetChallenges(ctx, &api.GetChallengesParams{
+	challs, _, err := data.fm.Client.GetChallenges(ctx, &api.GetChallengesParams{
 		Type: utils.Ptr("standard"),
 	}, WithTracerProvider(data.fm.Tp))
 	if err != nil {

--- a/provider/challenge_standard_resource.go
+++ b/provider/challenge_standard_resource.go
@@ -111,7 +111,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 			Prerequisites: preqs,
 		}
 	}
-	res, err := r.fm.Client.PostChallenges(ctx, &api.PostChallengesParams{
+	res, _, err := r.fm.Client.PostChallenges(ctx, &api.PostChallengesParams{
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
@@ -142,7 +142,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 	// Create tags
 	challTags := make([]types.String, 0, len(data.Tags))
 	for _, tag := range data.Tags {
-		_, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
+		_, _, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Value:     tag.ValueString(),
 		}, WithTracerProvider(r.fm.Tp))
@@ -162,7 +162,7 @@ func (r *challengeStandardResource) Create(ctx context.Context, req resource.Cre
 	// Create topics
 	challTopics := make([]types.String, 0, len(data.Topics))
 	for _, topic := range data.Topics {
-		_, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
+		_, _, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Type:      "challenge",
 			Value:     topic.ValueString(),
@@ -229,7 +229,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 			Prerequisites: preqs,
 		}
 	}
-	_, err := r.fm.Client.PatchChallenge(ctx, data.ID.ValueString(), &api.PatchChallengeParams{
+	_, _, err := r.fm.Client.PatchChallenge(ctx, data.ID.ValueString(), &api.PatchChallengeParams{
 		Name:           data.Name.ValueString(),
 		Category:       data.Category.ValueString(),
 		Description:    data.Description.ValueString(),
@@ -252,7 +252,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	// Update its tags (drop them all, create new ones)
-	challTags, err := r.fm.Client.GetChallengeTags(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	challTags, _, err := r.fm.Client.GetChallengeTags(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -261,7 +261,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 	for _, tag := range challTags {
-		if err := r.fm.Client.DeleteTag(ctx, strconv.Itoa(tag.ID), WithTracerProvider(r.fm.Tp)); err != nil {
+		if _, err := r.fm.Client.DeleteTag(ctx, strconv.Itoa(tag.ID), WithTracerProvider(r.fm.Tp)); err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",
 				fmt.Sprintf("Unable to delete tag %d of challenge %s, got error: %s", tag.ID, data.ID.ValueString(), err),
@@ -271,7 +271,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 	}
 	tags := make([]types.String, 0, len(data.Tags))
 	for _, tag := range data.Tags {
-		_, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
+		_, _, err := r.fm.Client.PostTags(ctx, &api.PostTagsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Value:     tag.ValueString(),
 		}, WithTracerProvider(r.fm.Tp))
@@ -289,7 +289,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	// Update its topics (drop them all, create new ones)
-	challTopics, err := r.fm.Client.GetChallengeTopics(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	challTopics, _, err := r.fm.Client.GetChallengeTopics(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -298,7 +298,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 	for _, topic := range challTopics {
-		if err := r.fm.Client.DeleteTopic(ctx, &api.DeleteTopicArgs{
+		if _, err := r.fm.Client.DeleteTopic(ctx, &api.DeleteTopicArgs{
 			ID:   strconv.Itoa(topic.ID),
 			Type: "challenge",
 		}, WithTracerProvider(r.fm.Tp)); err != nil {
@@ -311,7 +311,7 @@ func (r *challengeStandardResource) Update(ctx context.Context, req resource.Upd
 	}
 	topics := make([]types.String, 0, len(data.Topics))
 	for _, topic := range data.Topics {
-		_, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
+		_, _, err := r.fm.Client.PostTopics(ctx, &api.PostTopicsParams{
 			Challenge: utils.Atoi(data.ID.ValueString()),
 			Type:      "challenge",
 			Value:     topic.ValueString(),
@@ -345,7 +345,7 @@ func (r *challengeStandardResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	if err := r.fm.Client.DeleteChallenge(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteChallenge(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete challenge, got error: %s", err))
 		return
 	}
@@ -364,7 +364,7 @@ func (r *challengeStandardResource) ImportState(ctx context.Context, req resourc
 //
 
 func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *Client, diags diag.Diagnostics, opts ...Option) {
-	res, err := client.GetChallenge(ctx, chall.ID.ValueString(), opts...)
+	res, _, err := client.GetChallenge(ctx, chall.ID.ValueString(), opts...)
 	if err != nil {
 		diags.AddError("Client Error", fmt.Sprintf("Unable to read challenge %s, got error: %s", chall.ID.ValueString(), err))
 		return
@@ -385,7 +385,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 
 	// Get subresources
 	// => Requirements
-	resReqs, err := client.GetChallengeRequirements(ctx, strconv.Itoa(id), opts...)
+	resReqs, _, err := client.GetChallengeRequirements(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",
@@ -407,7 +407,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 	chall.Requirements = reqs
 
 	// => Tags
-	resTags, err := client.GetChallengeTags(ctx, strconv.Itoa(id), opts...)
+	resTags, _, err := client.GetChallengeTags(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",
@@ -421,7 +421,7 @@ func (chall *ChallengeStandardResourceModel) Read(ctx context.Context, client *C
 	}
 
 	// => Topics
-	resTopics, err := client.GetChallengeTopics(ctx, strconv.Itoa(id), opts...)
+	resTopics, _, err := client.GetChallengeTopics(ctx, strconv.Itoa(id), opts...)
 	if err != nil {
 		diags.AddError(
 			"Client Error",

--- a/provider/client.go
+++ b/provider/client.go
@@ -51,28 +51,28 @@ func (cli *Client) Login(ctx context.Context, params *api.LoginParams, opts ...O
 
 // region brackets
 
-func (cli *Client) GetBrackets(ctx context.Context, params *api.GetBracketsParams, opts ...Option) ([]*api.Bracket, error) {
+func (cli *Client) GetBrackets(ctx context.Context, params *api.GetBracketsParams, opts ...Option) ([]*api.Bracket, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetBrackets(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PostBrackets(ctx context.Context, params *api.PostBracketsParams, opts ...Option) (*api.Bracket, error) {
+func (cli *Client) PostBrackets(ctx context.Context, params *api.PostBracketsParams, opts ...Option) (*api.Bracket, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostBrackets(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchBrackets(ctx context.Context, id string, params *api.PatchBracketsParams, opts ...Option) (*api.Bracket, error) {
+func (cli *Client) PatchBrackets(ctx context.Context, id string, params *api.PatchBracketsParams, opts ...Option) (*api.Bracket, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchBrackets(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteBrackets(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteBrackets(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -81,49 +81,49 @@ func (cli *Client) DeleteBrackets(ctx context.Context, id string, opts ...Option
 
 // region challenges
 
-func (cli *Client) GetChallenges(ctx context.Context, params *api.GetChallengesParams, opts ...Option) ([]*api.Challenge, error) {
+func (cli *Client) GetChallenges(ctx context.Context, params *api.GetChallengesParams, opts ...Option) ([]*api.Challenge, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetChallenges(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PostChallenges(ctx context.Context, params *api.PostChallengesParams, opts ...Option) (*api.Challenge, error) {
+func (cli *Client) PostChallenges(ctx context.Context, params *api.PostChallengesParams, opts ...Option) (*api.Challenge, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostChallenges(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchChallenge(ctx context.Context, id string, params *api.PatchChallengeParams, opts ...Option) (*api.Challenge, error) {
+func (cli *Client) PatchChallenge(ctx context.Context, id string, params *api.PatchChallengeParams, opts ...Option) (*api.Challenge, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchChallenge(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallengeTags(ctx context.Context, id string, opts ...Option) ([]*api.Tag, error) {
+func (cli *Client) GetChallengeTags(ctx context.Context, id string, opts ...Option) ([]*api.Tag, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetChallengeTags(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallengeRequirements(ctx context.Context, id string, opts ...Option) (*api.Requirements, error) {
+func (cli *Client) GetChallengeRequirements(ctx context.Context, id string, opts ...Option) (*api.Requirements, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetChallengeRequirements(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallengeFiles(ctx context.Context, id string, opts ...Option) ([]*api.File, error) {
+func (cli *Client) GetChallengeFiles(ctx context.Context, id string, opts ...Option) ([]*api.File, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetChallengeFiles(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallengeHints(ctx context.Context, id string, opts ...Option) ([]*api.Hint, error) {
+func (cli *Client) GetChallengeHints(ctx context.Context, id string, opts ...Option) ([]*api.Hint, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -132,28 +132,28 @@ func (cli *Client) GetChallengeHints(ctx context.Context, id string, opts ...Opt
 
 // region tags
 
-func (cli *Client) PostTags(ctx context.Context, params *api.PostTagsParams, opts ...Option) (*api.Tag, error) {
+func (cli *Client) PostTags(ctx context.Context, params *api.PostTagsParams, opts ...Option) (*api.Tag, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostTags(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteTag(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteTag(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.DeleteTag(id, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteChallenge(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteChallenge(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.DeleteChallenge(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallenge(ctx context.Context, id string, opts ...Option) (*api.Challenge, error) {
+func (cli *Client) GetChallenge(ctx context.Context, id string, opts ...Option) (*api.Challenge, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -162,21 +162,21 @@ func (cli *Client) GetChallenge(ctx context.Context, id string, opts ...Option) 
 
 // region topics
 
-func (cli *Client) PostTopics(ctx context.Context, params *api.PostTopicsParams, opts ...Option) (*api.Topic, error) {
+func (cli *Client) PostTopics(ctx context.Context, params *api.PostTopicsParams, opts ...Option) (*api.Topic, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostTopics(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteTopic(ctx context.Context, params *api.DeleteTopicArgs, opts ...Option) error {
+func (cli *Client) DeleteTopic(ctx context.Context, params *api.DeleteTopicArgs, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.DeleteTopic(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetChallengeTopics(ctx context.Context, id string, opts ...Option) ([]*api.Topic, error) {
+func (cli *Client) GetChallengeTopics(ctx context.Context, id string, opts ...Option) ([]*api.Topic, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -185,14 +185,14 @@ func (cli *Client) GetChallengeTopics(ctx context.Context, id string, opts ...Op
 
 // region files
 
-func (cli *Client) PostFiles(ctx context.Context, params *api.PostFilesParams, opts ...Option) ([]*api.File, error) {
+func (cli *Client) PostFiles(ctx context.Context, params *api.PostFilesParams, opts ...Option) ([]*api.File, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostFiles(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetFile(ctx context.Context, id string, opts ...Option) (*api.File, error) {
+func (cli *Client) GetFile(ctx context.Context, id string, opts ...Option) (*api.File, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -206,7 +206,7 @@ func (cli *Client) GetFileContent(ctx context.Context, file *api.File, opts ...O
 	return cli.sub.GetFileContent(file, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteFile(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteFile(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -215,28 +215,28 @@ func (cli *Client) DeleteFile(ctx context.Context, id string, opts ...Option) er
 
 // region flags
 
-func (cli *Client) PostFlags(ctx context.Context, params *api.PostFlagsParams, opts ...Option) (*api.Flag, error) {
+func (cli *Client) PostFlags(ctx context.Context, params *api.PostFlagsParams, opts ...Option) (*api.Flag, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostFlags(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetFlag(ctx context.Context, id string, opts ...Option) (*api.Flag, error) {
+func (cli *Client) GetFlag(ctx context.Context, id string, opts ...Option) (*api.Flag, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetFlag(id, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchFlag(ctx context.Context, id string, params *api.PatchFlagParams, opts ...Option) (*api.Flag, error) {
+func (cli *Client) PatchFlag(ctx context.Context, id string, params *api.PatchFlagParams, opts ...Option) (*api.Flag, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchFlag(id, params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteFlag(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteFlag(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -245,28 +245,28 @@ func (cli *Client) DeleteFlag(ctx context.Context, id string, opts ...Option) er
 
 // region hints
 
-func (cli *Client) PostHints(ctx context.Context, params *api.PostHintsParams, opts ...Option) (*api.Hint, error) {
+func (cli *Client) PostHints(ctx context.Context, params *api.PostHintsParams, opts ...Option) (*api.Hint, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostHints(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetHint(ctx context.Context, id string, params *api.GetHintParams, opts ...Option) (*api.Hint, error) {
+func (cli *Client) GetHint(ctx context.Context, id string, params *api.GetHintParams, opts ...Option) (*api.Hint, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetHint(id, params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchHint(ctx context.Context, id string, params *api.PatchHintsParams, opts ...Option) (*api.Hint, error) {
+func (cli *Client) PatchHint(ctx context.Context, id string, params *api.PatchHintsParams, opts ...Option) (*api.Hint, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchHint(id, params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteHint(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteHint(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -275,28 +275,28 @@ func (cli *Client) DeleteHint(ctx context.Context, id string, opts ...Option) er
 
 // region solutions
 
-func (cli *Client) PostSolutions(ctx context.Context, params *api.PostSolutionsParams, opts ...Option) (*api.Solution, error) {
+func (cli *Client) PostSolutions(ctx context.Context, params *api.PostSolutionsParams, opts ...Option) (*api.Solution, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostSolutions(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetSolutions(ctx context.Context, id string, params *api.GetSolutionsParams, opts ...Option) (*api.Solution, error) {
+func (cli *Client) GetSolutions(ctx context.Context, id string, params *api.GetSolutionsParams, opts ...Option) (*api.Solution, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetSolutions(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchSolutions(ctx context.Context, id string, params *api.PatchSolutionsParams, opts ...Option) (*api.Solution, error) {
+func (cli *Client) PatchSolutions(ctx context.Context, id string, params *api.PatchSolutionsParams, opts ...Option) (*api.Solution, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchSolutions(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteSolutions(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteSolutions(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -305,56 +305,56 @@ func (cli *Client) DeleteSolutions(ctx context.Context, id string, opts ...Optio
 
 // region teams
 
-func (cli *Client) GetTeams(ctx context.Context, params *api.GetTeamsParams, opts ...Option) ([]*api.Team, error) {
+func (cli *Client) GetTeams(ctx context.Context, params *api.GetTeamsParams, opts ...Option) ([]*api.Team, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetTeams(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PostTeams(ctx context.Context, params *api.PostTeamsParams, opts ...Option) (*api.Team, error) {
+func (cli *Client) PostTeams(ctx context.Context, params *api.PostTeamsParams, opts ...Option) (*api.Team, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostTeams(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchTeam(ctx context.Context, id string, params *api.PatchTeamsParams, opts ...Option) (*api.Team, error) {
+func (cli *Client) PatchTeam(ctx context.Context, id string, params *api.PatchTeamsParams, opts ...Option) (*api.Team, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchTeam(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetTeam(ctx context.Context, id string, opts ...Option) (*api.Team, error) {
+func (cli *Client) GetTeam(ctx context.Context, id string, opts ...Option) (*api.Team, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetTeam(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteTeam(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteTeam(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.DeleteTeam(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) PostTeamMembers(ctx context.Context, id string, params *api.PostTeamsMembersParams, opts ...Option) (int, error) {
+func (cli *Client) PostTeamMembers(ctx context.Context, id string, params *api.PostTeamsMembersParams, opts ...Option) (int, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostTeamMembers(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetTeamMembers(ctx context.Context, id string, opts ...Option) ([]int, error) {
+func (cli *Client) GetTeamMembers(ctx context.Context, id string, opts ...Option) ([]int, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetTeamMembers(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteTeamMembers(ctx context.Context, id string, params *api.DeleteTeamMembersParams, opts ...Option) ([]int, error) {
+func (cli *Client) DeleteTeamMembers(ctx context.Context, id string, params *api.DeleteTeamMembersParams, opts ...Option) ([]int, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
@@ -363,35 +363,35 @@ func (cli *Client) DeleteTeamMembers(ctx context.Context, id string, params *api
 
 // region users
 
-func (cli *Client) GetUsers(ctx context.Context, params *api.GetUsersParams, opts ...Option) ([]*api.User, error) {
+func (cli *Client) GetUsers(ctx context.Context, params *api.GetUsersParams, opts ...Option) ([]*api.User, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetUsers(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) PostUsers(ctx context.Context, params *api.PostUsersParams, opts ...Option) (*api.User, error) {
+func (cli *Client) PostUsers(ctx context.Context, params *api.PostUsersParams, opts ...Option) (*api.User, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PostUsers(params, apiOptions(ctx)...)
 }
 
-func (cli *Client) GetUser(ctx context.Context, id string, opts ...Option) (*api.User, error) {
+func (cli *Client) GetUser(ctx context.Context, id string, opts ...Option) (*api.User, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.GetUser(utils.Atoi(id), apiOptions(ctx)...)
 }
 
-func (cli *Client) PatchUser(ctx context.Context, id string, params *api.PatchUsersParams, opts ...Option) (*api.User, error) {
+func (cli *Client) PatchUser(ctx context.Context, id string, params *api.PatchUsersParams, opts ...Option) (*api.User, *api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 
 	return cli.sub.PatchUser(utils.Atoi(id), params, apiOptions(ctx)...)
 }
 
-func (cli *Client) DeleteUser(ctx context.Context, id string, opts ...Option) error {
+func (cli *Client) DeleteUser(ctx context.Context, id string, opts ...Option) (*api.MetaResponse, error) {
 	ctx, span := StartAPISpan(ctx, getTracer(opts...))
 	defer span.End()
 

--- a/provider/file_resource.go
+++ b/provider/file_resource.go
@@ -149,7 +149,7 @@ func (r *fileResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !data.ChallengeID.IsNull() {
 		params.Challenge = utils.Ptr(utils.Atoi(data.ChallengeID.ValueString()))
 	}
-	res, err := r.fm.Client.PostFiles(ctx, params, WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.PostFiles(ctx, params, WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -181,7 +181,7 @@ func (r *fileResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	res, err := r.fm.Client.GetFile(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.GetFile(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"CTFd Error",
@@ -240,7 +240,7 @@ func (r *fileResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.fm.Client.DeleteFile(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteFile(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete file %s, got error: %s", data.ID.ValueString(), err))
 		return
 	}
@@ -254,7 +254,7 @@ func (r *fileResource) ImportState(ctx context.Context, req resource.ImportState
 
 // XXX this helper only exist because CTFd does not return the challenge id of a file if it exist...
 func lookForChallengeId(ctx context.Context, client *Client, fileID int, diags diag.Diagnostics, opts ...Option) types.String {
-	challs, err := client.GetChallenges(ctx, &api.GetChallengesParams{
+	challs, _, err := client.GetChallenges(ctx, &api.GetChallengesParams{
 		View: utils.Ptr("admin"), // required, else CTFd only returns the "visible" challenges
 	}, opts...)
 	if err != nil {
@@ -266,7 +266,7 @@ func lookForChallengeId(ctx context.Context, client *Client, fileID int, diags d
 	}
 
 	for _, chall := range challs {
-		files, err := client.GetChallengeFiles(ctx, strconv.Itoa(chall.ID), opts...)
+		files, _, err := client.GetChallengeFiles(ctx, strconv.Itoa(chall.ID), opts...)
 		if err != nil {
 			diags.AddError(
 				"CTFd Error",

--- a/provider/flag_resource.go
+++ b/provider/flag_resource.go
@@ -128,7 +128,7 @@ func (r *flagResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Create flag
-	res, err := r.fm.Client.PostFlags(ctx, &api.PostFlagsParams{
+	res, _, err := r.fm.Client.PostFlags(ctx, &api.PostFlagsParams{
 		Challenge: utils.Atoi(data.ChallengeID.ValueString()),
 		Content:   data.Content.ValueString(),
 		Data:      data.Data.ValueString(),
@@ -164,7 +164,7 @@ func (r *flagResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Retrieve flag
-	res, err := r.fm.Client.GetFlag(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.GetFlag(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -196,7 +196,7 @@ func (r *flagResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Update flag
-	if _, err := r.fm.Client.PatchFlag(ctx, data.ID.ValueString(), &api.PatchFlagParams{
+	if _, _, err := r.fm.Client.PatchFlag(ctx, data.ID.ValueString(), &api.PatchFlagParams{
 		ID:      data.ID.ValueString(),
 		Content: data.Content.ValueString(),
 		Data:    data.Data.ValueString(),
@@ -225,7 +225,7 @@ func (r *flagResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.fm.Client.DeleteFlag(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteFlag(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete flag %s, got error: %s", data.ID.ValueString(), err))
 		return
 	}

--- a/provider/hint_resource.go
+++ b/provider/hint_resource.go
@@ -121,7 +121,7 @@ func (r *hintResource) Create(ctx context.Context, req resource.CreateRequest, r
 		id, _ := strconv.Atoi(preq.ValueString())
 		reqs = append(reqs, id)
 	}
-	res, err := r.fm.Client.PostHints(ctx, &api.PostHintsParams{
+	res, _, err := r.fm.Client.PostHints(ctx, &api.PostHintsParams{
 		ChallengeID: utils.Atoi(data.ChallengeID.ValueString()),
 		Title:       data.Title.ValueStringPointer(),
 		Content:     data.Content.ValueString(),
@@ -160,7 +160,7 @@ func (r *hintResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Retrieve hint
-	h, err := r.fm.Client.GetHint(ctx, data.ID.ValueString(), &api.GetHintParams{
+	h, _, err := r.fm.Client.GetHint(ctx, data.ID.ValueString(), &api.GetHintParams{
 		Preview: utils.Ptr(true), // mimic a preview to get the hint even if not unlocked by the admin
 	}, WithTracerProvider(r.fm.Tp))
 	if err != nil {
@@ -171,7 +171,7 @@ func (r *hintResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 	// XXX cannot get hint by ID, so we need to query them all
-	hints, err := r.fm.Client.GetChallengeHints(ctx, strconv.Itoa(h.ChallengeID), WithTracerProvider(r.fm.Tp))
+	hints, _, err := r.fm.Client.GetChallengeHints(ctx, strconv.Itoa(h.ChallengeID), WithTracerProvider(r.fm.Tp))
 	hint := (*api.Hint)(nil)
 	for _, h := range hints {
 		if h.ID == utils.Atoi(data.ID.ValueString()) {
@@ -220,7 +220,7 @@ func (r *hintResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		id, _ := strconv.Atoi(preq.ValueString())
 		preqs = append(preqs, id)
 	}
-	if _, err := r.fm.Client.PatchHint(ctx, data.ID.ValueString(), &api.PatchHintsParams{
+	if _, _, err := r.fm.Client.PatchHint(ctx, data.ID.ValueString(), &api.PatchHintsParams{
 		ChallengeID: utils.Atoi(data.ChallengeID.ValueString()),
 		Title:       data.Title.ValueStringPointer(),
 		Content:     data.Content.ValueString(),
@@ -252,7 +252,7 @@ func (r *hintResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.fm.Client.DeleteHint(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteHint(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete hint %s, got error: %s", data.ID.ValueString(), err))
 		return
 	}

--- a/provider/solution_resource.go
+++ b/provider/solution_resource.go
@@ -110,7 +110,7 @@ func (r *solutionResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Create solution
-	res, err := r.fm.Client.PostSolutions(ctx, &api.PostSolutionsParams{
+	res, _, err := r.fm.Client.PostSolutions(ctx, &api.PostSolutionsParams{
 		ChallengeID: utils.Atoi(data.ChallengeID.ValueString()),
 		Content:     data.Content.ValueString(),
 		State:       data.State.ValueString(),
@@ -145,7 +145,7 @@ func (r *solutionResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	// Retrieve solution
-	res, err := r.fm.Client.GetSolutions(ctx, data.ID.ValueString(), nil, WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.GetSolutions(ctx, data.ID.ValueString(), nil, WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -176,7 +176,7 @@ func (r *solutionResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	// Update solution
-	if _, err := r.fm.Client.PatchSolutions(ctx, data.ID.ValueString(), &api.PatchSolutionsParams{
+	if _, _, err := r.fm.Client.PatchSolutions(ctx, data.ID.ValueString(), &api.PatchSolutionsParams{
 		Content: data.Content.ValueString(),
 		State:   data.State.ValueString(),
 	}, WithTracerProvider(r.fm.Tp)); err != nil {
@@ -203,7 +203,7 @@ func (r *solutionResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	if err := r.fm.Client.DeleteSolutions(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteSolutions(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete solution of challenge %s, got error: %s", data.ChallengeID.ValueString(), err))
 		return
 	}

--- a/provider/team_data_source.go
+++ b/provider/team_data_source.go
@@ -117,40 +117,47 @@ func (data *teamDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	ctx, span := StartTFSpan(ctx, data.fm.Tp.Tracer(serviceName), data)
 	defer span.End()
 
-	var state teamsDataSourceModel
-
-	teams, err := data.fm.Client.GetTeams(ctx, &api.GetTeamsParams{}, WithTracerProvider(data.fm.Tp))
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read CTFd Teams",
-			err.Error(),
-		)
-		return
+	state := teamsDataSourceModel{
+		ID:    types.StringValue("placeholder"),
+		Teams: []teamResourceModel{},
 	}
-
-	state.Teams = make([]teamResourceModel, 0, len(teams))
-	for _, t := range teams {
-		// Flatten response
-		members := make([]basetypes.StringValue, 0, len(t.Members))
-		for _, tm := range t.Members {
-			members = append(members, types.StringValue(strconv.Itoa(tm)))
+	for page := 1; ; page++ {
+		tms, meta, err := data.fm.Client.GetTeams(ctx, &api.GetTeamsParams{
+			Page: &page,
+		}, WithTracerProvider(data.fm.Tp))
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to Read CTFd Teams",
+				err.Error(),
+			)
+			return
 		}
-		state.Teams = append(state.Teams, teamResourceModel{
-			ID:          types.StringValue(strconv.Itoa(t.ID)),
-			Name:        types.StringValue(t.Name),
-			Email:       types.StringValue(*t.Email),
-			Password:    types.StringValue("placeholder"),
-			Website:     types.StringValue(*t.Website),
-			Affiliation: types.StringValue(*t.Affiliation),
-			Country:     types.StringValue(*t.Country),
-			Hidden:      types.BoolValue(t.Hidden),
-			Banned:      types.BoolValue(t.Banned),
-			Members:     members,
-			Captain:     types.StringValue(strconv.Itoa(*t.CaptainID)),
-		})
-	}
 
-	state.ID = types.StringValue("placeholder")
+		for _, t := range tms {
+			members := make([]basetypes.StringValue, 0, len(t.Members))
+			for _, tm := range t.Members {
+				members = append(members, types.StringValue(strconv.Itoa(tm)))
+			}
+			state.Teams = append(state.Teams, teamResourceModel{
+				ID:          types.StringValue(strconv.Itoa(t.ID)),
+				Name:        types.StringValue(t.Name),
+				Email:       types.StringValue(*t.Email),
+				Password:    types.StringValue("placeholder"),
+				Website:     types.StringValue(*t.Website),
+				Affiliation: types.StringValue(*t.Affiliation),
+				Country:     types.StringValue(*t.Country),
+				Hidden:      types.BoolValue(t.Hidden),
+				Banned:      types.BoolValue(t.Banned),
+				Members:     members,
+				Captain:     types.StringValue(strconv.Itoa(*t.CaptainID)),
+			})
+		}
+
+		// Keep pushing until no more pages to fetch
+		if meta == nil || meta.Pagination.Pages == page {
+			break
+		}
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -146,7 +146,7 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	res, err := r.fm.Client.PostTeams(ctx, &api.PostTeamsParams{
+	res, _, err := r.fm.Client.PostTeams(ctx, &api.PostTeamsParams{
 		Name:        data.Name.ValueString(),
 		Email:       data.Email.ValueString(),
 		Password:    data.Password.ValueString(),
@@ -170,7 +170,7 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// => Members
 	for _, mem := range data.Members {
-		_, err := r.fm.Client.PostTeamMembers(ctx, strconv.Itoa(res.ID), &api.PostTeamsMembersParams{
+		_, _, err := r.fm.Client.PostTeamMembers(ctx, strconv.Itoa(res.ID), &api.PostTeamsMembersParams{
 			UserID: utils.Atoi(mem.ValueString()),
 		}, WithTracerProvider(r.fm.Tp))
 		if err != nil {
@@ -183,7 +183,7 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	// => Captain
 	cap := utils.Atoi(data.Captain.ValueString())
-	if _, err := r.fm.Client.PatchTeam(ctx, strconv.Itoa(res.ID), &api.PatchTeamsParams{
+	if _, _, err := r.fm.Client.PatchTeam(ctx, strconv.Itoa(res.ID), &api.PatchTeamsParams{
 		CaptainID: &cap,
 		Fields:    []api.Field{},
 	}, WithTracerProvider(r.fm.Tp)); err != nil {
@@ -211,7 +211,7 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	teamId := utils.Atoi(data.ID.ValueString())
-	res, err := r.fm.Client.GetTeam(ctx, strconv.Itoa(teamId), WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.GetTeam(ctx, strconv.Itoa(teamId), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -233,7 +233,7 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	// password is not returned, which is good :)
 
 	// => Members
-	mems, err := r.fm.Client.GetTeamMembers(ctx, strconv.Itoa(teamId), WithTracerProvider(r.fm.Tp))
+	mems, _, err := r.fm.Client.GetTeamMembers(ctx, strconv.Itoa(teamId), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -264,7 +264,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	_, err := r.fm.Client.PatchTeam(ctx, data.ID.ValueString(), &api.PatchTeamsParams{
+	_, _, err := r.fm.Client.PatchTeam(ctx, data.ID.ValueString(), &api.PatchTeamsParams{
 		Name:        data.Name.ValueStringPointer(),
 		Email:       data.Email.ValueStringPointer(),
 		Password:    data.Password.ValueStringPointer(),
@@ -285,7 +285,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// => Members
-	currentMembers, err := r.fm.Client.GetTeamMembers(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	currentMembers, _, err := r.fm.Client.GetTeamMembers(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -303,7 +303,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			}
 		}
 		if !exists {
-			if _, err := r.fm.Client.PostTeamMembers(ctx, data.ID.ValueString(), &api.PostTeamsMembersParams{
+			if _, _, err := r.fm.Client.PostTeamMembers(ctx, data.ID.ValueString(), &api.PostTeamsMembersParams{
 				UserID: utils.Atoi(tfMember.ValueString()),
 			}, WithTracerProvider(r.fm.Tp)); err != nil {
 				resp.Diagnostics.AddError(
@@ -325,7 +325,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			}
 		}
 		if !exists {
-			if _, err := r.fm.Client.DeleteTeamMembers(ctx, data.ID.ValueString(), &api.DeleteTeamMembersParams{
+			if _, _, err := r.fm.Client.DeleteTeamMembers(ctx, data.ID.ValueString(), &api.DeleteTeamMembersParams{
 				UserID: currentMember,
 			}, WithTracerProvider(r.fm.Tp)); err != nil {
 				resp.Diagnostics.AddError(
@@ -341,7 +341,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	// => Captain
 	cap := utils.Ptr(utils.Atoi(data.Captain.ValueString()))
-	if _, err := r.fm.Client.PatchTeam(ctx, data.ID.ValueString(), &api.PatchTeamsParams{
+	if _, _, err := r.fm.Client.PatchTeam(ctx, data.ID.ValueString(), &api.PatchTeamsParams{
 		CaptainID: cap,
 		Fields:    []api.Field{},
 	}, WithTracerProvider(r.fm.Tp)); err != nil {
@@ -368,7 +368,7 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.fm.Client.DeleteTeam(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteTeam(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
 			fmt.Sprintf("Unable to delete team %s, got error: %s", data.ID.ValueString(), err),

--- a/provider/user_data_source.go
+++ b/provider/user_data_source.go
@@ -119,37 +119,46 @@ func (data *userDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	ctx, span := StartTFSpan(ctx, data.fm.Tp.Tracer(serviceName), data)
 	defer span.End()
 
-	var state usersDataSourceModel
-
-	users, err := data.fm.Client.GetUsers(ctx, &api.GetUsersParams{}, WithTracerProvider(data.fm.Tp))
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read CTFd Users",
-			err.Error(),
-		)
-		return
+	state := usersDataSourceModel{
+		ID:    types.StringValue("placeholder"),
+		Users: []userResourceModel{},
 	}
 
-	state.Users = make([]userResourceModel, 0, len(users))
-	for _, u := range users {
-		// Flatten response
-		state.Users = append(state.Users, userResourceModel{
-			ID:          types.StringValue(strconv.Itoa(u.ID)),
-			Name:        types.StringValue(u.Name),
-			Email:       types.StringPointerValue(u.Email),
-			Password:    types.StringValue("placeholder"),
-			Website:     types.StringPointerValue(u.Website),
-			Affiliation: types.StringPointerValue(u.Affiliation),
-			Country:     types.StringPointerValue(u.Country),
-			Language:    types.StringPointerValue(u.Language),
-			Type:        types.StringPointerValue(u.Type),
-			Verified:    types.BoolPointerValue(u.Verified),
-			Hidden:      types.BoolPointerValue(u.Hidden),
-			Banned:      types.BoolPointerValue(u.Banned),
-		})
-	}
+	for page := 1; ; page++ {
+		usrs, meta, err := data.fm.Client.GetUsers(ctx, &api.GetUsersParams{
+			Page: &page,
+		}, WithTracerProvider(data.fm.Tp))
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to Read CTFd Users",
+				err.Error(),
+			)
+			return
+		}
 
-	state.ID = types.StringValue("placeholder")
+		for _, u := range usrs {
+			// Flatten response
+			state.Users = append(state.Users, userResourceModel{
+				ID:          types.StringValue(strconv.Itoa(u.ID)),
+				Name:        types.StringValue(u.Name),
+				Email:       types.StringPointerValue(u.Email),
+				Password:    types.StringValue("placeholder"),
+				Website:     types.StringPointerValue(u.Website),
+				Affiliation: types.StringPointerValue(u.Affiliation),
+				Country:     types.StringPointerValue(u.Country),
+				Language:    types.StringPointerValue(u.Language),
+				Type:        types.StringPointerValue(u.Type),
+				Verified:    types.BoolPointerValue(u.Verified),
+				Hidden:      types.BoolPointerValue(u.Hidden),
+				Banned:      types.BoolPointerValue(u.Banned),
+			})
+		}
+
+		// Keep pushing until no more pages to fetch
+		if meta == nil || meta.Pagination.Pages == page {
+			break
+		}
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/provider/user_resource.go
+++ b/provider/user_resource.go
@@ -161,7 +161,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	res, err := r.fm.Client.PostUsers(ctx, &api.PostUsersParams{
+	res, _, err := r.fm.Client.PostUsers(ctx, &api.PostUsersParams{
 		Name:        data.Name.ValueString(),
 		Email:       data.Email.ValueString(),
 		Password:    data.Password.ValueString(),
@@ -202,7 +202,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	res, err := r.fm.Client.GetUser(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
+	res, _, err := r.fm.Client.GetUser(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
@@ -242,7 +242,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	_, err := r.fm.Client.PatchUser(ctx, data.ID.ValueString(), &api.PatchUsersParams{
+	_, _, err := r.fm.Client.PatchUser(ctx, data.ID.ValueString(), &api.PatchUsersParams{
 		Name:        data.Name.ValueString(),
 		Email:       data.Email.ValueString(),
 		Password:    data.Password.ValueStringPointer(),
@@ -281,7 +281,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.fm.Client.DeleteUser(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
+	if _, err := r.fm.Client.DeleteUser(ctx, data.ID.ValueString(), WithTracerProvider(r.fm.Tp)); err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
 			fmt.Sprintf("Unable to delete user %s, got error: %s", data.ID.ValueString(), err),


### PR DESCRIPTION
Bump go-ctfd to 0.18.0, i.e., add support of pagination for applicable datasources (users and teams).

Before, more than 50 users or teams could not be imported with datasources.