### PR TITLE
fix(ci): group Hashicorp plugin modules for proper dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,8 @@ updates:
       interval: "weekly"
     assignees:
       - "pandatix"
+    groups:
+      # interdependencies between plugin modules
+      hashicorp-terraform-plugin:
+        patterns:
+          - "github.com/hashicorp/terraform-plugin-*"


### PR DESCRIPTION
This PR fixes the issue of having many Hashicorp plugin modules bumped in different PRs by dependabot (they need to be updated at once to properly work).